### PR TITLE
Load census data

### DIFF
--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -564,3 +564,46 @@
       columns:
       - zipcode
       filter: {}
+- table:
+    schema: public
+    name: census_geographies
+  select_permissions:
+  - role: anonymous
+    permission:
+      columns:
+      - id
+      - geoid
+      - geography
+      - name
+      - city
+      - county
+      - zcta
+      - population
+      - age
+      - race
+      - geom
+      filter: {}
+- table:
+    schema: public
+    name: county_testing_results
+  select_permissions:
+  - role: anonymous
+    permission:
+      columns:
+      - id
+      - date
+      - county
+      - confirmed_cases
+      - deaths
+      - total_tested
+      - census_geography_id
+      filter: {}
+  object_relationships:
+  - name: census
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: census_geographies
+        column_mapping:
+          census_geography_id: id

--- a/hasura/migrations/1597178255016_census_table/down.sql
+++ b/hasura/migrations/1597178255016_census_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE public.census_geographies;

--- a/hasura/migrations/1597178255016_census_table/up.sql
+++ b/hasura/migrations/1597178255016_census_table/up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE public.census_geographies (
+    id serial,
+    geoid text NOT NULL,
+    geography text NOT NULL,
+    name text NOT NULL,
+    city text,
+    county text,
+    zcta text,
+    population jsonb NOT NULL default '{}'::jsonb,
+    age jsonb NOT NULL default '{}'::jsonb,
+    race jsonb NOT NULL default '{}'::jsonb,
+    geom public.geometry NOT NULL
+);
+
+ALTER TABLE ONLY public.census_geographies
+    ADD CONSTRAINT census_geographies_pk PRIMARY KEY (id);
+ALTER TABLE ONLY public.census_geographies
+    ADD CONSTRAINT census_geographies_geoid_geography_unique UNIQUE (geoid, geography);

--- a/hasura/migrations/1597246297208_county_table/down.sql
+++ b/hasura/migrations/1597246297208_county_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE public.county_testing_results;

--- a/hasura/migrations/1597246297208_county_table/up.sql
+++ b/hasura/migrations/1597246297208_county_table/up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE public.county_testing_results (
+    id serial,
+    date date NOT NULL,
+    county text NOT NULL,
+    confirmed_cases integer,
+    deaths integer,
+    total_tested integer,
+    census_geography_id integer,
+    FOREIGN KEY (census_geography_id) REFERENCES public.census_geographies (id)
+);
+
+ALTER TABLE ONLY public.county_testing_results
+    ADD CONSTRAINT county_testing_results_pk PRIMARY KEY (id);
+ALTER TABLE ONLY public.county_testing_results
+    ADD CONSTRAINT county_testing_results_date_county_key UNIQUE (date, county);

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,13 @@
+const STATE = "state";
+const COUNTY = "county";
+const PLACE = "place";
+const ZCTA = "zcta";
+const GEOGRAPHIES = [STATE, COUNTY, PLACE, ZCTA];
+
+module.exports = {
+  STATE,
+  COUNTY,
+  PLACE,
+  ZCTA,
+  GEOGRAPHIES,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime-corejs3": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@cronvel/get-pixels": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@cronvel/get-pixels/-/get-pixels-3.3.1.tgz",
@@ -609,6 +618,15 @@
         "cross-env": "^6.0.3"
       }
     },
+    "citysdk": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/citysdk/-/citysdk-2.1.4.tgz",
+      "integrity": "sha512-3P8BzDiH85vpjmII2YEKPHdS03nUAmg0o6jMrLA3Gf3qmRr+EYM3NCcuDNBZBh3LPnByL3pifCRJUKhLWzRDtQ==",
+      "requires": {
+        "xmlhttprequest": "^1.8.0",
+        "xregexp": "^4.3.0"
+      }
+    },
     "clean-stack": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.0.tgz",
@@ -759,6 +777,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
     },
     "cross-env": {
       "version": "6.0.3",
@@ -1555,6 +1578,11 @@
         "esprima": "~4.0.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -1914,6 +1942,19 @@
       "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "requires": {
         "async-limiter": "~1.0.0"
+      }
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+    },
+    "xregexp": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
+      "integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
+      "requires": {
+        "@babel/runtime-corejs3": "^7.8.3"
       }
     },
     "zen-observable": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "scripts/loadData.js",
   "scripts": {
+    "load_census": "node --max_old_space_size=4096 ./scripts/loadCensus.js",
+    "load_state_county": "node ./scripts/loadStateCountyResults.js",
     "load_zip_geo": "node ./scripts/loadZIPCodeGeojson.js",
     "load_zips": "node ./scripts/loadZIPCodes.js",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -19,6 +21,7 @@
   },
   "homepage": "https://github.com/thechicagoreporter/il-covid19-api#readme",
   "dependencies": {
+    "citysdk": "^2.1.4",
     "dotenv": "^8.2.0",
     "graphqurl": "^0.3.3",
     "lodash": "^4.17.15",

--- a/scripts/loadCensus.js
+++ b/scripts/loadCensus.js
@@ -1,0 +1,292 @@
+const dotenv = require("dotenv");
+const fs = require("fs");
+const census = require("citysdk");
+const { query } = require("../lib/api");
+const { STATE, COUNTY, PLACE, ZCTA } = require("../lib/constants");
+
+dotenv.config();
+
+const CENSUS_RESOLUTION = "500k";
+const CENSUS_VINTAGE = 2018;
+const CENSUS_SOURCE_PATH = ["acs", "acs5", "profile"];
+const CITYSDK_KEY = process.env.CITYSDK_KEY;
+const CENSUS_VALUES = [
+  "NAME",
+  "DP05_0001E",
+  "DP05_0001M",
+  "DP05_0001PE",
+  "DP05_0001PM",
+  "DP05_0077E",
+  "DP05_0077M",
+  "DP05_0077PE",
+  "DP05_0077PM",
+  "DP05_0078E",
+  "DP05_0078M",
+  "DP05_0078PE",
+  "DP05_0078PM",
+  "DP05_0079E",
+  "DP05_0079M",
+  "DP05_0079PE",
+  "DP05_0079PM",
+  "DP05_0080E",
+  "DP05_0080M",
+  "DP05_0080PE",
+  "DP05_0080PM",
+  "DP05_0081E",
+  "DP05_0081M",
+  "DP05_0081PE",
+  "DP05_0081PM",
+  "DP05_0071E",
+  "DP05_0071M",
+  "DP05_0071PE",
+  "DP05_0071PM",
+  "DP05_0057E",
+  "DP05_0057M",
+  "DP05_0057PE",
+  "DP05_0057PM",
+];
+
+const censusQuery = `
+    mutation($objects: [census_geographies_insert_input!]!) {
+        insert_census_geographies(
+            objects: $objects,
+            on_conflict: {
+              constraint: census_geographies_geoid_geography_unique,
+              update_columns: [name, city, county, zcta, population, age, race, geom]
+            }
+        ) {
+            affected_rows
+        }
+    }
+`;
+
+const censusPromise = (args) =>
+  new Promise((resolve, reject) =>
+    census(args, (err, json) => (err ? reject(err) : resolve(json)))
+  );
+
+const createGeoid = (result) => {
+  if ("zip-code-tabulation-area" in result) {
+    return result["zip-code-tabulation-area"];
+  } else if ("county" in result) {
+    return `${result.state}${result.county}`;
+  } else if ("place" in result) {
+    return `${result.state}${result.place}`;
+  } else {
+    return result.state;
+  }
+};
+
+const processGeography = (result) => {
+  if ("zip-code-tabulation-area" in result) {
+    return ZCTA;
+  } else if ("county" in result) {
+    return COUNTY;
+  } else if ("place" in result) {
+    return PLACE;
+  } else {
+    return STATE;
+  }
+};
+
+const processName = ({ NAME }) =>
+  NAME.replace("ZCTA5 ", "")
+    .replace(" County", "")
+    .replace(" city", "")
+    .replace(", Illinois", "")
+    .trim();
+
+const shouldUseGeography = (properties) =>
+  (!properties["zip-code-tabulation-area"] && properties["state"] === "17") ||
+  ["60", "61", "62"].includes(
+    (properties["zip-code-tabulation-area"] || "").slice(0, 2)
+  );
+
+const baseArgs = {
+  vintage: CENSUS_VINTAGE,
+  sourcePath: CENSUS_SOURCE_PATH,
+  statsKey: CITYSDK_KEY,
+};
+
+const geoHierarchies = [
+  { state: "17" },
+  { state: "17", county: "*" },
+  { state: "17", place: "14000" },
+  { "zip-code-tabulation-area": "*" },
+];
+
+const createDataMap = () =>
+  Promise.all(
+    geoHierarchies.map((geoHierarchy) =>
+      censusPromise({
+        ...baseArgs,
+        geoHierarchy,
+        values: CENSUS_VALUES,
+      })
+    )
+  )
+    .then((results) =>
+      results
+        .flat()
+        .filter(shouldUseGeography)
+        .map((result) => ({
+          ...result,
+          geoid: createGeoid(result),
+          name: processName(result),
+          geography: processGeography(result),
+          zcta:
+            "zip-code-tabulation-area" in result
+              ? result["zip-code-tabulation-area"]
+              : null,
+          city: "place" in result ? result.place : null,
+        }))
+        .reduce(
+          (
+            acc,
+            {
+              geoid,
+              name,
+              geography,
+              city,
+              county,
+              zcta,
+              DP05_0001E,
+              DP05_0001M,
+              DP05_0001PE,
+              DP05_0001PM,
+              DP05_0077E,
+              DP05_0077M,
+              DP05_0077PE,
+              DP05_0077PM,
+              DP05_0078E,
+              DP05_0078M,
+              DP05_0078PE,
+              DP05_0078PM,
+              DP05_0079E,
+              DP05_0079M,
+              DP05_0079PE,
+              DP05_0079PM,
+              DP05_0080E,
+              DP05_0080M,
+              DP05_0080PE,
+              DP05_0080PM,
+              DP05_0081E,
+              DP05_0081M,
+              DP05_0081PE,
+              DP05_0081PM,
+              DP05_0071E,
+              DP05_0071M,
+              DP05_0071PE,
+              DP05_0071PM,
+              DP05_0057E,
+              DP05_0057M,
+              DP05_0057PE,
+              DP05_0057PM,
+            }
+          ) => ({
+            ...acc,
+            [geoid]: {
+              geoid,
+              name,
+              geography,
+              city,
+              county,
+              zcta,
+              population: {
+                E: DP05_0001E,
+                M: DP05_0001M,
+                PE: DP05_0001PE,
+                PM: DP05_0001PM,
+              },
+              race: {
+                "AI/AN**": {
+                  E: DP05_0079E,
+                  M: DP05_0079M,
+                  PE: DP05_0079PE,
+                  PM: DP05_0079PM,
+                },
+                Asian: {
+                  E: DP05_0080E,
+                  M: DP05_0080M,
+                  PE: DP05_0080PE,
+                  PM: DP05_0080PM,
+                },
+                Black: {
+                  E: DP05_0078E,
+                  M: DP05_0078M,
+                  PE: DP05_0078PE,
+                  PM: DP05_0078PM,
+                },
+                Hispanic: {
+                  E: DP05_0071E,
+                  M: DP05_0071M,
+                  PE: DP05_0071PE,
+                  PM: DP05_0071PM,
+                },
+                "NH/PI*": {
+                  E: DP05_0081E,
+                  M: DP05_0081M,
+                  PE: DP05_0081PE,
+                  PM: DP05_0081PM,
+                },
+                Other: {
+                  E: DP05_0057E,
+                  M: DP05_0057M,
+                  PE: DP05_0057PE,
+                  PM: DP05_0057PM,
+                },
+                White: {
+                  E: DP05_0077E,
+                  M: DP05_0077M,
+                  PE: DP05_0077PE,
+                  PM: DP05_0077PM,
+                },
+              },
+            },
+          }),
+          {}
+        )
+    )
+    .catch(console.error);
+
+const loadCensusGeographies = () =>
+  Promise.all(
+    geoHierarchies.map((geoHierarchy) =>
+      censusPromise({
+        ...baseArgs,
+        geoHierarchy,
+        values: ["NAME"],
+        geoResolution: CENSUS_RESOLUTION,
+      })
+    )
+  )
+    .then((results) =>
+      results
+        .flat()
+        .map(({ features }) => features)
+        .flat()
+        .filter(({ properties }) => shouldUseGeography(properties))
+    )
+    .catch(console.error);
+
+async function loadCensus() {
+  const geoidDataMap = await createDataMap();
+  const censusGeographies = await loadCensusGeographies();
+  const censusDataGeographies = censusGeographies.map(
+    ({ properties, geometry }) => ({
+      geom: geometry,
+      ...(geoidDataMap[createGeoid(properties)] || {}),
+    })
+  );
+
+  await query({
+    query: censusQuery,
+    variables: {
+      objects: censusDataGeographies,
+    },
+  })
+    .then(console.log)
+    .catch(console.error);
+}
+
+loadCensus();


### PR DESCRIPTION
Should at least be progress on #4, #5, and #9. Keeps the same census data structure as #6 though

Some notes on this:

- It looks like the Hasura metadata doesn't match the schema in #6, but the database does so looks like that might be out of sync?
- Initially I was going to make the foreign key for `census_geographies` the combination of `geoid` and `geography` (not the best name), but I forgot that "Out of State" and "Unknown" are included as counties in the state's data, so I just used a general ID foreign key
- At first I was worried about doing a semi-manual join of county data to census data, but it's actually extremely fast so if it works for you it seems alright. Open to suggestions on that though, I'm guessing I'm missing something we could do in GraphQL
- I kept the census variables pretty explicit instead of trying to streamline those so that it'll fail loudly, but if we want to make that less verbose it's fine with me

Let me know if there's anything I should change here, thanks!
