### PR TITLE
Add alt ZIP code endpoint

### DIFF
--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -31,5 +31,7 @@ jobs:
         run: npm run load_state_county
       - name: Load ZIP codes
         run: npm run load_zips
+      - name: Load alt ZIP codes
+        run: npm run load_zips_alt
       - name: Refresh materialized views
         run: npm run refresh_views

--- a/package-lock.json
+++ b/package-lock.json
@@ -1872,6 +1872,15 @@
         "tree-kit": "^0.6.2"
       }
     },
+    "tiny-async-pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.1.0.tgz",
+      "integrity": "sha512-jIglyHF/9QdCC3662m/UMVADE6SlocBDpXdFLMZyiAfrw8MSG1pml7lwRtBMT6L/z4dddAxfzw2lpW2Vm42fyQ==",
+      "requires": {
+        "semver": "^5.5.0",
+        "yaassertion": "^1.0.0"
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2050,6 +2059,11 @@
       "requires": {
         "@babel/runtime-corejs3": "^7.8.3"
       }
+    },
+    "yaassertion": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/yaassertion/-/yaassertion-1.0.2.tgz",
+      "integrity": "sha512-sBoJBg5vTr3lOpRX0yFD+tz7wv/l2UPMFthag4HGTMPrypBRKerjjS8jiEnNMjcAEtPXjbHiKE0UwRR1W1GXBg=="
     },
     "zen-observable": {
       "version": "0.8.15",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "graphqurl": "^0.3.3",
     "lodash": "^4.17.15",
     "node-fetch": "^2.6.0",
-    "slugify": "^1.4.4"
+    "slugify": "^1.4.4",
+    "tiny-async-pool": "^1.1.0"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "load_census": "node --max_old_space_size=4096 ./scripts/loadCensus.js",
     "load_state_county": "node ./scripts/loadStateCountyResults.js",
     "load_zips": "node ./scripts/loadZIPCodes.js",
+    "load_zips_alt": "node ./scripts/loadZIPCodesAlt.js",
     "refresh_views": "node ./scripts/refreshViews.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/scripts/loadZIPCodesAlt.js
+++ b/scripts/loadZIPCodesAlt.js
@@ -1,0 +1,102 @@
+const fetch = require('node-fetch');
+const { query } = require('../lib/api');
+const { backupToS3 } = require("../lib/backup");
+const { unzip } = require('lodash');
+
+const sourceURL = 'https://idph.illinois.gov/DPHPublicInformation/api/COVID/GetZip'
+
+zipQuery = `
+    mutation($zipcodes: [zipcodes_insert_input!]!,
+             $counts: [zipcode_testing_results_insert_input!]!) {
+        insert_zipcodes(
+            objects: $zipcodes,  
+            on_conflict: {
+                constraint: zipcodes_pkey,
+                update_columns: [zipcode]
+            }
+        ) {
+            affected_rows
+        }
+        insert_zipcode_testing_results(
+            objects: $counts,  
+            on_conflict: {
+                constraint: zipcode_testing_results_date_zipcode_key,
+                update_columns: [confirmed_cases, total_tested, census_geography_id]
+            }
+        ) {
+            affected_rows
+        }
+    }
+`;
+
+const censusIdQuery = `
+  query {
+    census_geographies(where: {geography: {_eq: "zcta"}}) {
+      id
+      geoid
+    }
+  }
+`;
+
+async function loadDay(zipData) {
+  const {
+    data: { census_geographies: censusGeographies },
+  } = await query({ query: censusIdQuery });
+
+  const censusIdMap = censusGeographies.reduce(
+    (acc, { geoid, id }) => ({
+      ...acc,
+      [geoid]: id,
+    }),
+    {}
+  );
+
+  const updatedDate = `${zipData.lastUpdatedDate.year}-${zipData.lastUpdatedDate.month}-${zipData.lastUpdatedDate.day}`;
+
+    // Generate objects for all queries in one loop
+    const objects = zipData.zip_values.map(d => {
+        const census_geography_id = censusIdMap[d.zip] || null
+
+        return [
+            {   // ZIP codes + date-ZIP junction
+                zipcode: d.zip,
+                daily_counts: {
+                    data: [{
+                        date: updatedDate,
+                    }],
+                    on_conflict: {
+                        constraint: 'zipcode_date_pkey',
+                        update_columns: []
+                    }
+                },
+            },
+            {   // ZIP code date counts
+                zipcode: d.zip,
+                date: updatedDate,
+                confirmed_cases: d.confirmed_cases,
+                total_tested: d.total_tested,
+                census_geography_id,
+            },
+        ]
+    });
+
+    // Collect array columns as variables for query input
+    const [ zipcodes, counts, ] = unzip(objects);
+
+    return query({
+        query: zipQuery,
+        variables: { zipcodes, counts, },
+    })
+    .then((response) => console.log(response))
+    .catch((error) => console.error(error));
+}
+
+async function loadZIPCodesAlt() {
+    const data = await fetch(sourceURL).then(res => res.json())
+
+    backupToS3("GetZip.json", JSON.stringify(data));
+
+    loadDay(data)
+}
+
+loadZIPCodesAlt()

--- a/scripts/loadZIPCodesAlt.js
+++ b/scripts/loadZIPCodesAlt.js
@@ -1,13 +1,22 @@
-const fetch = require('node-fetch');
-const { query } = require('../lib/api');
+const fetch = require("node-fetch");
+const slugify = require("slugify");
+const { query } = require("../lib/api");
 const { backupToS3 } = require("../lib/backup");
-const { unzip } = require('lodash');
+const { unzip } = require("lodash");
+const asyncPool = require("tiny-async-pool");
 
-const sourceURL = 'https://idph.illinois.gov/DPHPublicInformation/api/COVID/GetZip'
+const sourceURL =
+  "https://idph.illinois.gov/DPHPublicInformation/api/COVID/GetZip";
+
+const demographicsURL =
+  "https://idph.illinois.gov/DPHPublicInformation/api/COVID/GetZipDemographics?zipCode=";
 
 zipQuery = `
     mutation($zipcodes: [zipcodes_insert_input!]!,
-             $counts: [zipcode_testing_results_insert_input!]!) {
+             $counts: [zipcode_testing_results_insert_input!]!,
+             $raceCounts: [zipcode_date_race_counts_insert_input!]!,
+             $genderCounts: [zipcode_date_gender_counts_insert_input!]!,
+             $ageCounts: [zipcode_date_age_counts_insert_input!]!) {
         insert_zipcodes(
             objects: $zipcodes,  
             on_conflict: {
@@ -26,6 +35,33 @@ zipQuery = `
         ) {
             affected_rows
         }
+        insert_zipcode_date_race_counts(
+            objects: $raceCounts,  
+            on_conflict: {
+                constraint: zipcode_date_race_counts_zipcode_date_key,
+                update_columns: []
+            }
+        ) {
+            affected_rows
+        }
+        insert_zipcode_date_gender_counts(
+            objects: $genderCounts,  
+            on_conflict: {
+                constraint: zipcode_date_gender_counts_zipcode_date_key,
+                update_columns: []
+            }
+        ) {
+            affected_rows
+        }
+        insert_zipcode_date_age_counts(
+            objects: $ageCounts,  
+            on_conflict: {
+                constraint: zipcode_date_age_counts_zipcode_date_key,
+                update_columns: []
+            }
+        ) {
+            affected_rows
+        }
     }
 `;
 
@@ -37,6 +73,41 @@ const censusIdQuery = `
     }
   }
 `;
+
+function flattenRaceDemographics(accumulator, demographic) {
+  const slug = slugify(demographic.description, {
+    replacement: "",
+    strict: true,
+    lower: true,
+  });
+  accumulator[`confirmed_cases_${slug}`] = demographic.count;
+  accumulator[`total_tested_${slug}`] = demographic.tested;
+  return accumulator;
+}
+
+function flattenGenderDemographics(accumulator, demographic) {
+  const slug = slugify(demographic.description, {
+    replacement: "",
+    strict: true,
+    lower: true,
+  });
+  accumulator[`confirmed_cases_${slug}`] = demographic.count;
+  accumulator[`total_tested_${slug}`] = demographic.tested;
+  return accumulator;
+}
+
+function flattenAgeDemographics(accumulator, demographic) {
+  const slug = demographic.age_group
+    .replace("<", "less_than_")
+    .replace("+", "_or_more")
+    .replace("-", "_to_")
+    .trim()
+    .toLowerCase();
+
+  accumulator[`confirmed_cases_${slug}`] = demographic.count;
+  accumulator[`total_tested_${slug}`] = demographic.tested;
+  return accumulator;
+}
 
 async function loadDay(zipData) {
   const {
@@ -53,50 +124,130 @@ async function loadDay(zipData) {
 
   const updatedDate = `${zipData.lastUpdatedDate.year}-${zipData.lastUpdatedDate.month}-${zipData.lastUpdatedDate.day}`;
 
-    // Generate objects for all queries in one loop
-    const objects = zipData.zip_values.map(d => {
-        const census_geography_id = censusIdMap[d.zip] || null
+  // Generate objects for all queries in one loop
+  const objects = zipData.zip_values.map((d) => {
+    const census_geography_id = censusIdMap[d.zip] || null;
 
-        return [
-            {   // ZIP codes + date-ZIP junction
-                zipcode: d.zip,
-                daily_counts: {
-                    data: [{
-                        date: updatedDate,
-                    }],
-                    on_conflict: {
-                        constraint: 'zipcode_date_pkey',
-                        update_columns: []
-                    }
-                },
+    const zipTestData = [
+      {
+        // ZIP codes + date-ZIP junction
+        zipcode: d.zip,
+        daily_counts: {
+          data: [
+            {
+              date: updatedDate,
             },
-            {   // ZIP code date counts
-                zipcode: d.zip,
-                date: updatedDate,
-                confirmed_cases: d.confirmed_cases,
-                total_tested: d.total_tested,
-                census_geography_id,
-            },
-        ]
-    });
+          ],
+          on_conflict: {
+            constraint: "zipcode_date_pkey",
+            update_columns: [],
+          },
+        },
+      },
+      {
+        // ZIP code date counts
+        zipcode: d.zip,
+        date: updatedDate,
+        confirmed_cases: d.confirmed_cases,
+        total_tested: d.total_tested,
+        census_geography_id,
+      },
+    ];
 
-    // Collect array columns as variables for query input
-    const [ zipcodes, counts, ] = unzip(objects);
+    let zipDemData = [null, null, null];
 
-    return query({
-        query: zipQuery,
-        variables: { zipcodes, counts, },
-    })
+    if (d.demographics && "age" in d.demographics) {
+      // Flatten race
+      const raceRow = d.demographics.race.reduce(flattenRaceDemographics, {});
+
+      // Flatten gender
+      const genderRow = d.demographics.gender.reduce(
+        flattenGenderDemographics,
+        {}
+      );
+
+      // Flatten age
+      const ageRow = d.demographics.age.reduce(flattenAgeDemographics, {});
+
+      zipDemData = [
+        {
+          // ZIP code date counts for race groups
+          zipcode: d.zip,
+          date: updatedDate,
+          ...raceRow,
+        },
+        {
+          // ZIP code date counts for gender groups
+          zipcode: d.zip,
+          date: updatedDate,
+          ...genderRow,
+        },
+        {
+          // ZIP code date counts for age groups
+          zipcode: d.zip,
+          date: updatedDate,
+          ...ageRow,
+        },
+      ];
+    }
+
+    return [...zipTestData, ...zipDemData];
+  });
+
+  // Collect array columns as variables for query input
+  const [zipcodes, counts, raceVals, genderVals, ageVals] = unzip(objects);
+
+  // Remove empty values for demographics
+  const [raceCounts, genderCounts, ageCounts] = [
+    raceVals,
+    genderVals,
+    ageVals,
+  ].map((vals) => vals.filter((v) => v !== null));
+
+  return query({
+    query: zipQuery,
+    variables: { zipcodes, counts, raceCounts, genderCounts, ageCounts },
+  })
     .then((response) => console.log(response))
     .catch((error) => console.error(error));
 }
 
 async function loadZIPCodesAlt() {
-    const data = await fetch(sourceURL).then(res => res.json())
+  const { lastUpdatedDate, zip_values } = await fetch(sourceURL).then((res) =>
+    res.json()
+  );
+  const zipCodes = zip_values.map(({ zip }) => zip);
+  // Combine all ZIP code demographic data into a mapping of ZIP codes to demographics
+  const demographicsMap = (
+    await asyncPool(2, zipCodes, (zip) =>
+      fetch(`${demographicsURL}${zip}`)
+        .then((res) => res.json())
+        .then((data) => ({ ...data, zip }))
+        .catch((e) => {
+          console.error(e);
+          return { zip };
+        })
+    )
+  ).reduce((acc, { zip, ...curr }) => ({ ...acc, [zip]: curr }), {});
 
-    backupToS3("GetZip.json", JSON.stringify(data));
+  const zipData = zip_values.map(({ zip, ...d }) => ({
+    ...d,
+    zip,
+    demographics: demographicsMap[zip],
+  }));
 
-    loadDay(data)
+  backupToS3(
+    "GetZip.json",
+    JSON.stringify({
+      lastUpdatedDate,
+      zip_values: zipData,
+    })
+  );
+
+  await loadDay({
+    lastUpdatedDate,
+    zip_values: zipData,
+  });
 }
 
-loadZIPCodesAlt()
+loadZIPCodesAlt();


### PR DESCRIPTION
Adds a loading script that pulls from the new endpoint without the demographic info. For now I'm loading in addition to the other endpoint just in case. Duplicating a lot of code from the other ZIP code script instead of generalizing since it seems likely that either one could change